### PR TITLE
[1.12] Backport fixes

### DIFF
--- a/src/main/java/com/sintinium/oauth/GuiEventHandler.java
+++ b/src/main/java/com/sintinium/oauth/GuiEventHandler.java
@@ -39,6 +39,7 @@ public class GuiEventHandler {
                     statusText.setColor(0xFF5555);
                 }
             });
+            thread.setDaemon(true);
             thread.start();
 
             event.getButtonList().addAll(buttonList);

--- a/src/main/java/com/sintinium/oauth/GuiEventHandler.java
+++ b/src/main/java/com/sintinium/oauth/GuiEventHandler.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 @Mod.EventBusSubscriber(modid = "oauth", value = Side.CLIENT)
 public class GuiEventHandler {
-    private static TextWidget statusText = new TextWidget(10 + 66 + 3, 12, "Status: offline");
+    private static TextWidget statusText = new TextWidget(10 + 66 + 3, 12, "Status: loading");
 
     @SubscribeEvent
     public static void multiplayerScreenOpen(GuiScreenEvent.InitGuiEvent.Post event) {

--- a/src/main/java/com/sintinium/oauth/gui/LoginLoadingScreen.java
+++ b/src/main/java/com/sintinium/oauth/gui/LoginLoadingScreen.java
@@ -25,7 +25,12 @@ public class LoginLoadingScreen extends GuiScreen {
         this.lastScreen = callingScreen;
         this.onCancel = onCancel;
         this.isMicrosoft = isMicrosoft;
-        updateText.set("Check your browser");
+
+        if (this.isMicrosoft) {
+            updateText.set("Check your browser");
+        } else {
+            updateText.set("Authorizing you with Mojang");
+        }
     }
 
     public void updateText(String text) {

--- a/src/main/java/com/sintinium/oauth/gui/LoginScreen.java
+++ b/src/main/java/com/sintinium/oauth/gui/LoginScreen.java
@@ -115,6 +115,7 @@ public class LoginScreen extends GuiScreen {
                     }
                 }
             });
+            thread.setDaemon(true);
             thread.start();
         }, this::updateLoginButton, () -> this.mojangLoginButton.displayString = "Login"));
 

--- a/src/main/java/com/sintinium/oauth/gui/LoginScreen.java
+++ b/src/main/java/com/sintinium/oauth/gui/LoginScreen.java
@@ -125,14 +125,13 @@ public class LoginScreen extends GuiScreen {
             Minecraft.getMinecraft().displayGuiScreen(lastScreen);
         }));
 
-        this.cleanUp();
-
         if (OAuthConfig.isSavedPassword()) {
             this.usernameWidget.setText(OAuthConfig.getUsername());
             this.passwordWidget.setText(OAuthConfig.getPassword());
             this.savePasswordWidget.setIsChecked(true);
         }
 
+        this.cleanUp();
     }
 
     private void saveLoginInfo() {

--- a/src/main/java/com/sintinium/oauth/gui/LoginTypeScreen.java
+++ b/src/main/java/com/sintinium/oauth/gui/LoginTypeScreen.java
@@ -41,6 +41,7 @@ public class LoginTypeScreen extends GuiScreen {
                 }
             });
             Minecraft.getMinecraft().displayGuiScreen(loadingScreen);
+            thread.setDaemon(true);
             thread.start();
         }));
 

--- a/src/main/java/com/sintinium/oauth/gui/LoginTypeScreen.java
+++ b/src/main/java/com/sintinium/oauth/gui/LoginTypeScreen.java
@@ -27,6 +27,8 @@ public class LoginTypeScreen extends GuiScreen {
         }));
         this.addButton(new ActionButton(microsoftLoginId, this.width / 2 - 100, this.height / 2 + 2, 200, 20, "Microsoft Login", () -> {
             final MicrosoftLogin login = new MicrosoftLogin();
+            LoginLoadingScreen loadingScreen = new LoginLoadingScreen(lastScreen, this, login::cancelLogin, true);
+            login.setUpdateStatusConsumer(loadingScreen::updateText);
             Thread thread = new Thread(() -> {
                 try {
                     login.login(() -> {
@@ -38,7 +40,7 @@ public class LoginTypeScreen extends GuiScreen {
                     Minecraft.getMinecraft().displayGuiScreen(new ErrorScreen(true, e));
                 }
             });
-            Minecraft.getMinecraft().displayGuiScreen(new LoginLoadingScreen(lastScreen, this, login::cancelLogin, true));
+            Minecraft.getMinecraft().displayGuiScreen(loadingScreen);
             thread.start();
         }));
 

--- a/src/main/java/com/sintinium/oauth/login/LoginUtil.java
+++ b/src/main/java/com/sintinium/oauth/login/LoginUtil.java
@@ -1,6 +1,7 @@
 package com.sintinium.oauth.login;
 
 import com.mojang.authlib.Agent;
+import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.UserType;
 import com.mojang.authlib.exceptions.AuthenticationException;
 import com.mojang.authlib.exceptions.AuthenticationUnavailableException;
@@ -42,7 +43,9 @@ public class LoginUtil {
         lastCheck = System.currentTimeMillis();
         try {
             minecraftSessionService.joinServer(session.getProfile(), session.getToken(), uuid);
-            if (minecraftSessionService.hasJoinedServer(session.getProfile(), uuid, null).isComplete()) {
+            GameProfile mssProfile = minecraftSessionService.hasJoinedServer(session.getProfile(),
+                uuid, null);
+            if (mssProfile != null && mssProfile.isComplete()) {
                 wasOnline = true;
                 return true;
             } else {


### PR DESCRIPTION
The original PR was dumb. Decided to add a couple more QoL fixes.

- Status should be initialized as `Loading`, not `Offline`
- Prevented the LoginUtil NPE caused by null SessionService response (based on 2c2a54a)
- Backported Microsoft login progress messages
- Fix the Mojang login button being disabled when loading a saved password